### PR TITLE
Participants: Add unique index on conversation_id and user_id

### DIFF
--- a/messenger.sql
+++ b/messenger.sql
@@ -125,6 +125,10 @@ CREATE TABLE IF NOT EXISTS `participants` (
 ENGINE = InnoDB;
 
 SHOW WARNINGS;
+CREATE UNIQUE INDEX `participants_UNIQUE` ON `participants` (
+   `conversation_id`, `users_id`) VISIBLE;
+
+SHOW WARNINGS;
 
 -- -----------------------------------------------------
 -- Table `reports`


### PR DESCRIPTION
This prevents accidentally adding same user to the same conversation multiple
times.